### PR TITLE
Update control-port-filter-python.service

### DIFF
--- a/lib/systemd/system/control-port-filter-python.service
+++ b/lib/systemd/system/control-port-filter-python.service
@@ -26,6 +26,24 @@ Restart=always
 ##
 
 PrivateTmp=yes
+PrivateDevices=yes
+
+ProtectSystem=full
+ProtectHome=yes
+
+NoNewPrivileges=yes
+
+SystemCallFilter=close
+SystemCallFilter=open
+SystemCallFilter=link
+SystemCallFilter=access
+SystemCallFilter=kill
+SystemCallFilter=ioctl
+SystemCallFilter=readlink
+SystemCallFilter=stat64
+SystemCallFilter=getsockopt
+
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
syscall whitelist added.
/usr /boot and /etc are read-only.
access to /home /run/user is denied.
turns off all physical device access.